### PR TITLE
separate handlers for cancel/stop intents and sessionended requests

### DIFF
--- a/lambda/custom/index.js
+++ b/lambda/custom/index.js
@@ -639,17 +639,34 @@ const CancelResponseHandler = {
   },
 };
 
+const CancelAndStopIntentHandler = {
+	canHandle(handlerInput) {
+		return handlerInput.requestEnvelope.request.type === 'IntentRequest'
+      && (handlerInput.requestEnvelope.request.intent.name === 'AMAZON.CancelIntent'
+        || handlerInput.requestEnvelope.request.intent.name === 'AMAZON.StopIntent');
+	},
+	handle(handlerInput) {
+    console.log('IN: CancelAndStopIntentHandler.handle');
+		return handlerInput.responseBuilder
+			.speak(getRandomGoodbye())
+			.getResponse();
+	},
+};
+
 const SessionEndedHandler = {
   canHandle(handlerInput) {
-    return handlerInput.requestEnvelope.request.type === 'SessionEndedRequest' ||
-      (handlerInput.requestEnvelope.request.type === 'IntentRequest' && handlerInput.requestEnvelope.request.intent.name === 'AMAZON.StopIntent') ||
-      (handlerInput.requestEnvelope.request.type === 'IntentRequest' && handlerInput.requestEnvelope.request.intent.name === 'AMAZON.CancelIntent');
+    return handlerInput.requestEnvelope.request.type === 'SessionEndedRequest';
   },
   handle(handlerInput) {
     console.log('IN: SessionEndedHandler.handle');
-    return handlerInput.responseBuilder
-      .speak(getRandomGoodbye())
-      .getResponse();
+    const { request } = handlerInput.requestEnvelope;
+    // log the reason why the session was ended
+    console.log(`Session ended with reason: ${request.reason}`);
+    // log the error if any
+    if (request.error) {
+      console.log(`Session ended with error: ${JSON.stringify(request.error)}`);
+    }
+    return handlerInput.responseBuilder.getResponse();
   },
 };
 
@@ -775,6 +792,7 @@ exports.handler = Alexa.SkillBuilders.standard()
     ProductDetailHandler,
     BuyHandler,
     CancelSubscriptionHandler,
+    CancelAndStopIntentHandler,
     SessionEndedHandler,
     HelpHandler,
     FallbackHandler,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Split SessionEndedHandler in two handlers : 

-  One handler for AMAZON. StopIntent & AMAZON.CancelIntent to return an actual prompt to the user. Handler Name : CancelAndStopIntentHandler

- Keep the SessionEndedHandler only for SessionEndedRequest type of request to *not* send any prompt and log session ended reason and error (if any).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
