### PR TITLE
Removed unnecessary categories from sample text

### DIFF
--- a/instructions/3-create-isp.md
+++ b/instructions/3-create-isp.md
@@ -47,13 +47,10 @@ This sample uses four in-skill products -- 3 one-time purchases (sometimes refer
     **Display name**| History Pack | Science Pack | Space Pack
     **One sentence description** | The history pack is a great addition because you will hear facts about history. | The science pack is a great addition because you will hear facts about science. | The space pack is a great addition because you will hear facts about space.
     **Detailed Description**| The history pack expands the set of facts shared with you to include facts about history. | The science pack expands the set of facts shared with you to include facts about science. | The space pack expands the set of facts shared with you to include facts about space.
-    **Example Phrases**| buy history pack | buy science pack | buy space pack
     **Small Icon** (Placeholder)| https://s3.amazonaws.com/ask-samples-resources/icons/moneyicon_108.png | https://s3.amazonaws.com/ask-samples-resources/icons/moneyicon_108.png | https://s3.amazonaws.com/ask-samples-resources/icons/moneyicon_108.png
     **Large Icon** (Placeholder) | https://s3.amazonaws.com/ask-samples-resources/icons/moneyicon_512.png | https://s3.amazonaws.com/ask-samples-resources/icons/moneyicon_512.png | https://s3.amazonaws.com/ask-samples-resources/icons/moneyicon_512.png
-    **Keywords**| history | science | space
     **Purchase prompt description**| The history pack adds over 10 history facts into the set of facts randomly chosen to be shared with you. | The science pack adds over 10 science facts into the set of facts randomly chosen to be shared with you. | The space pack adds over 10 space facts into the set of facts randomly chosen to be shared with you.
     **Purchase confirmation description**| Thanks for purchasing the history pack.  You now have access to history facts! | Thanks for purchasing the science pack.  You now have access to science facts! | Thanks for purchasing the space pack.  You now have access to space facts!
-    **Privacy Policy URL** (Placeholder)| https://localhost/privacy.html | https://localhost/privacy.html | https://localhost/privacy.html
     **Tax Category** (Placeholder) | Information Services | Information Services | Information Services
 
     > These above placeholder values are suitable to be used in the sample, however you should expect to use your own icons and urls when creating your in-skill products.  Failure to do so will prevent your skill from being certified.


### PR DESCRIPTION
*Description of changes:*
The sample text for the History, Science, and Space packs included information like the privacy policy and keywords that the current console does not allow you to edit.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
